### PR TITLE
deprecate mos-tls-tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Available Options:
     使用v2ray-plugin的选项5时，请将CloudFlare后台Crypto页面里的SSL设置，改为 Full 或 Full (strict) 模式（前者不验证
 服务器证书，后者则会），否则，在浏览器打开你的域名会提示 ”重定向的次数过多“ 的错误！！！
 	
-    使用mos-tls-tunnel时，client开启了跳过验证模式，通信过程中client不会验证server的certificate chain 和 host name，用于自签证书的域名可以随意（不需要自备域名）。
+    使用mos-tls-tunnel时，client开启了跳过验证模式，通信过程中client不会验证server的certificate chain 和 host name，用于自签证书的域名可以随意（不需要自备域名）。mos-tls-tunnel已停止开发。但不影响使用。simple-tls是mos-tls-tunnel仅保留tls的后续版本，仍在更新。
 
     使用simple-tls时，由于v0.3.4版本和最新版本只有部分兼容，请注意使用对应版本的客户端。
 


### PR DESCRIPTION
在Readme中标注mos-tls-tunnel已停止更新并被simple-tls替代。